### PR TITLE
fix: 不適切なリンクの記述

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -39,13 +39,13 @@ const Layout = ({ children }) => {
         <div id="footerContainer">
           <div className="row">
             <div className="half">
-              <Link to={/about/}>このサイトについて</Link>
+              <Link to="/about">このサイトについて</Link>
             </div>
             <div className="half" style={{ textAlign: `right` }}>
               <img
                 src="https://drive.google.com/uc?id=1ReaOXbZz2mHy2CKZ7cQONvot6vp3S02m"
-                alt={`筑波大学`}
-                id={`footerLogo`}
+                alt="筑波大学"
+                id="footerLogo"
               />
             </div>
           </div>


### PR DESCRIPTION
`<Link to={/about/}>`だと` <Link to={/about/.toString()}>`となって、動くもののバグの温床になるので修正した。
その他propsの文字列に関しても修正した。