### PR TITLE
[Chore] sanitize.cssの導入 fix #61

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15123,6 +15123,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sanitize.css": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-11.0.0.tgz",
+      "integrity": "sha512-Ox0X2lk0kOGeODJgT9S9HFv0j5Cz89ir9ILylj62/vejHPdMmahmetfocoQwyiAnseeXyDa+KIbO6ZQJe5n2Lg==",
+      "dev": true
+    },
     "sass-graph": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint-staged": "^10.0.8",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
+    "sanitize.css": "^11.0.0",
     "stylelint": "^13.2.1",
     "stylelint-config-recess-order": "^2.0.4",
     "stylelint-config-standard": "^20.0.0"

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
 import { useStaticQuery, graphql, Link } from "gatsby"
 
 import Header from "./header"
-import "./layout.scss"
+import "sanitize.css"
 
 const Layout = ({ children }) => {
   const data = useStaticQuery(graphql`

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -23,6 +23,10 @@ main {
   margin: 0 auto;
 }
 
+img {
+  max-width: 100%;
+}
+
 /* トップページポスター一覧 */
 .categories {
   ul.scrollList {


### PR DESCRIPTION
## 修正するIssue

#61 

## 変更点

`layout.scss`の使用をやめ、[sanitize.css](https://csstools.github.io/sanitize.css/) を導入しました。
ただし、以下の理由により`layout.scss`のファイル自体は削除せずに残しています。

`layout.scss`には本来リセットCSSが果たすべき責務以上の記述がなされていたため、メジャーなリセットCSSである sanitize.css に切り替えた際に、`layout.scss` ありきで記述されていた一部のスタイル崩れてしまいました。
実際に確認した範囲では `img` に指定されていた `max-width: 100%;` の記述がなくなったことで、画面内の全 `img` オブジェクトが異常なサイズで表示されました。
このようなスタイル崩れが起こった際に `layout.scss` を参照して修正する必要があるため、当面の間はこのファイルを削除せず残しておこうと思います。一定の時間がたちスタイルの崩れがないことが確認できた時点で削除しましょう。

なお、`layout.scss`を import していた唯一のファイルである `layout.js` の import は削除しているので、このままでもビルド後の成果物に `layout.scss`が残留することはないと思われます。