### PR TITLE
トップページUIの再実装

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -5,6 +5,12 @@ module.exports = {
   ],
   rules: {
     "indentation": 2,
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": ["include","mixin","each"]
+      }
+    ]
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,47 +1,23 @@
-import React from "react"
-import { graphql, useStaticQuery, Link } from "gatsby"
-// import { Link } from "gatsby"
+import React, { useState } from "react"
+import { graphql, useStaticQuery, Link, navigate } from "gatsby"
+import "./index.scss"
 
 import Layout from "../components/layout"
 // import Image from "../components/image"
 import SEO from "../components/seo"
 
 const IndexPage = () => {
-  const data = useStaticQuery(graphql`
+  const [lastTouchedItem, setLastTouchedItem] = useState(null)
+  const { orgs } = useStaticQuery(graphql`
     {
-      sports: allShinkanWebOrg(filter: { activityType: { eq: "体育系" } }) {
+      orgs: allShinkanWebOrg {
         edges {
           node {
             posterImageUrls
             name
             primaryKey
-          }
-        }
-      }
-      culture: allShinkanWebOrg(filter: { activityType: { eq: "文化系" } }) {
-        edges {
-          node {
-            posterImageUrls
-            name
-            primaryKey
-          }
-        }
-      }
-      art: allShinkanWebOrg(filter: { activityType: { eq: "芸術系" } }) {
-        edges {
-          node {
-            posterImageUrls
-            name
-            primaryKey
-          }
-        }
-      }
-      others: allShinkanWebOrg(filter: { activityType: { eq: "その他" } }) {
-        edges {
-          node {
-            posterImageUrls
-            name
-            primaryKey
+            activityType
+            activityIntroduce
           }
         }
       }
@@ -50,86 +26,40 @@ const IndexPage = () => {
   return (
     <Layout>
       <SEO title="ホーム" />
-      <div className="categories sports">
-        <h2>体育系</h2>
-        <div>
-          <ul className="scrollList">
-            {data.sports.edges.map(({ node }) => {
-              return (
-                <li className="scrollItem">
-                  <Link to={"/org/" + node.primaryKey}>
-                    <img
-                      src={node.posterImageUrls[0]}
-                      alt={node.name}
-                      loading="lazy"
-                    />
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
-      </div>
+      <div className="page--index">
+        <ul className="org-list">
+          {orgs.edges.map(({ node: org }) => (
+            <li className="org-list__item" key={org.primaryKey}>
+              <Link to={`/org/${org.primaryKey}`}>
+                <figure className="org-list__item__poster">
+                  <img src={org.posterImageUrls[0]} alt="" />
+                  <figcaption>
+                    <h2 className="org-list__item__name">{org.name}</h2>
+                    <p className="org-list__item__activity-introduce">
+                      {org.activityIntroduce.substr(0, 100) + "..."}
+                    </p>
+                  </figcaption>
+                </figure>
+              </Link>
 
-      <div className="categories culture">
-        <h2>文化系</h2>
-        <div>
-          <ul className="scrollList">
-            {data.culture.edges.map(({ node }) => {
-              return (
-                <li className="scrollItem">
-                  <Link to={"/org/" + node.primaryKey}>
-                    <img
-                      src={node.posterImageUrls[0]}
-                      alt={node.name}
-                      loading="lazy"
-                    />
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
-      </div>
-      <div className="categories art">
-        <h2>芸術系</h2>
-        <div>
-          <ul className={"scrollList"}>
-            {data.art.edges.map(({ node }) => {
-              return (
-                <li className="scrollItem">
-                  <Link to={"/org/" + node.primaryKey}>
-                    <img
-                      src={node.posterImageUrls[0]}
-                      alt={node.name}
-                      loading="lazy"
-                    />
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
-      </div>
-      <div className="categories others">
-        <h2>その他</h2>
-        <div>
-          <ul className="scrollList">
-            {data.others.edges.map(({ node }) => {
-              return (
-                <li className="scrollItem">
-                  <Link to={"/org/" + node.primaryKey}>
-                    <img
-                      src={node.posterImageUrls[0]}
-                      alt={node.name}
-                      loading="lazy"
-                    />
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
+              <div // スマホ用
+                className="org-list__item__sp-caption"
+                onClick={e => {
+                  if (lastTouchedItem === org.primaryKey)
+                    navigate(`/org/${org.primaryKey}`)
+                  setLastTouchedItem(org.primaryKey)
+                }}
+              >
+                <div className="org-list__item__sp-caption__name">
+                  {org.name}
+                </div>
+                <div className="org-list__item__sp-caption__activity-introduce">
+                  {org.activityIntroduce.substr(0, 100) + "..."}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </Layout>
   )

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -1,0 +1,178 @@
+@import '../styles/vars.scss';
+@import '../styles/media.scss';
+
+.page--index {
+  padding: 0.1px 0;
+  background-color: $color-empty-bg;
+}
+
+.org-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(175px, 1fr));
+  grid-gap: 20px;
+  padding: 0;
+  margin: 20px 40px;
+  list-style-type: none;
+
+  @include mq-down() {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    grid-gap: 10px;
+    margin: 20px 10px;
+  }
+
+  // グリッドアイテム
+  &__item {
+    position: relative;
+
+    // 基本マージン（縦方向、横方向）
+    $margin-tb: 15px;
+    $margin-lr: 15px;
+
+    // キャプション部分の上下マージン
+    $caption-margin-tb: 20px;
+
+    // キャプション部分の高さ
+    $caption-height: 105px;
+
+    $color-bg: $color-dark-bg;
+    $color-text: #fff;
+
+    // アスペクト比維持のための擬似要素
+    &::before {
+      display: block;
+      margin-top: 7 / 5 * 100%;
+      content: "";
+    }
+
+    // ポップアップ
+    &__poster {
+      position: absolute;
+      top: -$margin-tb;
+      right: -$margin-lr;
+      width: calc(100% + #{$margin-lr} * 2);
+      height: calc(100% + #{$margin-tb + $caption-height + $caption-margin-tb + max($margin-tb, $caption-margin-tb)}); // アスペクト比が基準外でも規定サイズで表示させる
+      margin: 0;
+      background-color: transparent; // ホバー時以外は消しておく
+      transition: transform 0.2s ease 0s, background-color 0.2s ease 0s;
+
+      // マウスホバー時
+      &:hover {
+        z-index: 999; // 最前面に移動
+        background-color: $color-bg;
+        transform: scale3d(1.1, 1.1, 1);
+
+        figcaption {
+          opacity: 1;
+        }
+      }
+
+      // ポスター画像
+      img {
+        display: block;
+        width: calc(100% - #{$margin-lr} * 2);
+        height: calc(100% - #{$margin-tb + $caption-height + $caption-margin-tb + max($margin-tb, $caption-margin-tb)}); // アスペクト比が基準外でも規定サイズで表示させる
+        margin: $margin-tb $margin-lr;
+        object-fit: cover;
+        background: #fff; // 透過画像の背景を確保する
+        border: 1px solid #ddd;
+      }
+
+      figcaption {
+        position: relative;
+        height: $caption-height;
+        margin: $caption-margin-tb $margin-lr;
+        overflow-y: hidden;
+        color: $color-text;
+        pointer-events: none;
+        user-select: none;
+        opacity: 0; // ホバー時以外は消しておく
+        transition: opacity 0.2s ease 0s;
+
+        // テキスト下端を隠すシャドー
+        &::after {
+          position: absolute;
+          bottom: 0;
+          display: block;
+          width: 100%;
+          height: 50%;
+          content: "";
+          background: linear-gradient(transparent, $color-bg);
+        }
+      }
+
+      // スマホ版デザイン使用時
+      @include mq-down() {
+        pointer-events: none;
+      }
+    }
+
+    // 団体名
+    &__name {
+      margin: 0 0 6px;
+      font-size: 15px;
+    }
+
+    // 団体紹介文
+    &__activity-introduce {
+      font-size: 12px;
+    }
+
+    // スマホ版デザイン
+    &__sp-caption {
+      $sp-caption: &; // この階層を参照するセレクタ
+
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      overflow-y: hidden;
+      user-select: none;
+      background-color: rgba(0, 0, 0, 0.4);
+      opacity: 0;
+      transition: opacity 0.3s ease 0s;
+
+      // 文字情報（団体名、紹介文）
+      &__name,
+      &__activity-introduce {
+        display: inline-block;
+        color: #fff;
+        background-color: $color-dark-bg;
+        transition: transform 0.1s ease-out 0s;
+        transform: scale3d(0, 0, 1);
+      }
+
+      &__name {
+        margin: 20px 10px 15px;
+        font-size: 22px;
+        font-weight: $font-weight-bold;
+      }
+
+      &__activity-introduce {
+        max-height: 160px;
+        margin: 15px 10px;
+        overflow-y: hidden;
+        font-size: 13px;
+        transition-delay: 0.03s;
+      }
+
+      // ホバー時
+      &:hover {
+        opacity: 1;
+
+        // トランジションで動かす
+        #{$sp-caption}__name,
+        #{$sp-caption}__activity-introduce {
+          transform: scale3d(1, 1, 1);
+        }
+      }
+    }
+
+    // PC版デザイン適用時は表示しない
+    @include mq-up() {
+      &__sp-caption {
+        display: none;
+      }
+    }
+  }
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -11,8 +11,6 @@ a {
 }
 
 main {
-  max-width: 960px;
-  padding: 0 1rem 1.5rem;
   margin: 0 auto;
 }
 

--- a/src/styles/media.scss
+++ b/src/styles/media.scss
@@ -1,0 +1,29 @@
+$breakpoint-up-md: 'screen and (min-width: 768px)';
+$breakpoint-up-lg: 'screen and (min-width: 1000px)';
+
+$breakpoints-up:(
+  md: $breakpoint-up-md,
+  lg: $breakpoint-up-lg
+) !default;
+
+// min-width（これより大きい幅で適用）
+@mixin mq-up($bp: md) {
+  @media #{map-get($breakpoints-up, $bp)} {
+    @content;
+  }
+}
+
+$breakpoint-down-md: 'screen and (max-width: 767px)';
+$breakpoint-down-lg: 'screen and (max-width: 999px)';
+
+$breakpoints-down:(
+  md: $breakpoint-down-md,
+  lg: $breakpoint-down-lg
+) !default;
+
+// max-width（これより小さい幅で適用）
+@mixin mq-down($bp: md) {
+  @media #{map-get($breakpoints-down, $bp)} {
+    @content;
+  }
+}

--- a/src/styles/vars.scss
+++ b/src/styles/vars.scss
@@ -1,0 +1,10 @@
+// フォント
+$font-weight-bold: 700;
+$font-weight-normal: 400;
+
+// 色
+// 空の背景
+$color-empty-bg: #eee;
+
+// 濃色背景（ダークグレー）
+$color-dark-bg: #222;


### PR DESCRIPTION
## 修正するIssue

#63 

## 変更点
### トップページUI実装
* マークアップがセマンティックな記述になるよう、また極力スタイルシートのみ（スクリプトは避ける）で動かせるように努力したのですが、結局スマホデザインでのタップアクション制御はReactにロジックを実装せざるを得ませんでした。記述のセマンティックさも、「可能な限りPC版デザインでこなして、そこからスタイルシートの切替で作れなかったスマホUIはマークアップに付け足す」みたいな感じになってます。
* 作っていて微妙だなと思ったところを変えつつ作ったので、 #63 で載せてたデザインからは若干違うものになってしまいました……
* ページ固有のスタイルは`pages`ディレクトリに置いたけどよかったんだろうか……？

### グローバルなMedia Query・フォントウェイト・色の指定変数ファイルの作成
* `styles/media.sass` & `styles/vars.sass`
* こちらも命名や置き場所など気になるところあったら指摘ください！

### Chore
* グローバルにかかっていたbodyのマージン、max-width指定を削除
* stylelintルールの修正

## To be implemented
* フィルタUI・ロジック
* 表示順序の変更（現状は登録順のままです）
* 初期表示量の調整（リミットかけてないので全団体が読み込まれます）

![ezgif com-optimize](https://user-images.githubusercontent.com/7803255/78318430-a95e4980-759f-11ea-91fc-96cd74f4d2ad.gif)

![ezgif com-optimize (1)](https://user-images.githubusercontent.com/7803255/78318423-a2cfd200-759f-11ea-9b9f-9edf5ce4244b.gif)
