### PR TITLE
[Fix] リンクの色コントラスト確保 / フッターの背景色変更

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -151,7 +151,7 @@ footer {
   font-size: 0.8rem;
 
   /* height: 108px; */
-  background-color: #eaeaea;
+  background-color: #fff;
 
   .row {
     display: flex;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,3 +1,5 @@
+@import 'vars.scss';
+
 /* 全体 */
 @import url('https://fonts.googleapis.com/css?family=Noto+Sans+JP&display=swap');
 
@@ -6,7 +8,7 @@
 }
 
 a {
-  color: #00c1d5;
+  color: $color-primary;
   text-decoration: none;
 }
 

--- a/src/styles/vars.scss
+++ b/src/styles/vars.scss
@@ -8,3 +8,49 @@ $color-empty-bg: #eee;
 
 // 濃色背景（ダークグレー）
 $color-dark-bg: #222;
+
+// つくば紫バリエーション
+$color-primary: #60c;
+
+$color-primary-dark1: #5c00b8;
+$color-primary-dark2: #5200a3;
+$color-primary-dark3: #47008f;
+$color-primary-dark4: #3d007a;
+$color-primary-dark5: #306;
+$color-primary-dark6: #290052;
+$color-primary-dark7: #1f003d;
+$color-primary-dark8: #140029;
+$color-primary-dark9: #0a0014;
+
+$color-primary-light1: #751ad1;
+$color-primary-light2: #8533d6;
+$color-primary-light3: #944ddb;
+$color-primary-light4: #a366e0;
+$color-primary-light5: #b380e6;
+$color-primary-light6: #c299eb;
+$color-primary-light7: #d1b3f0;
+$color-primary-light8: #e0ccf5;
+$color-primary-light9: #f0e6fa;
+
+// フューチャーブルーバリエーション
+$color-secondary: #00c1d5;
+
+$color-secondary-dark1: #00aec0;
+$color-secondary-dark2: #009aaa;
+$color-secondary-dark3: #008795;
+$color-secondary-dark4: #007480;
+$color-secondary-dark5: #00616b;
+$color-secondary-dark6: #004d55;
+$color-secondary-dark7: #003a40;
+$color-secondary-dark8: #00272b;
+$color-secondary-dark9: #001315;
+
+$color-secondary-light1: #1ac7d9;
+$color-secondary-light2: #33cddd;
+$color-secondary-light3: #4dd4e2;
+$color-secondary-light4: #66dae6;
+$color-secondary-light5: #80e0ea;
+$color-secondary-light6: #99e6ee;
+$color-secondary-light7: #b3ecf2;
+$color-secondary-light8: #ccf3f7;
+$color-secondary-light9: #e6f9fb;

--- a/src/styles/vars.scss
+++ b/src/styles/vars.scss
@@ -9,48 +9,8 @@ $color-empty-bg: #eee;
 // 濃色背景（ダークグレー）
 $color-dark-bg: #222;
 
-// つくば紫バリエーション
+// つくば紫
 $color-primary: #60c;
 
-$color-primary-dark1: #5c00b8;
-$color-primary-dark2: #5200a3;
-$color-primary-dark3: #47008f;
-$color-primary-dark4: #3d007a;
-$color-primary-dark5: #306;
-$color-primary-dark6: #290052;
-$color-primary-dark7: #1f003d;
-$color-primary-dark8: #140029;
-$color-primary-dark9: #0a0014;
-
-$color-primary-light1: #751ad1;
-$color-primary-light2: #8533d6;
-$color-primary-light3: #944ddb;
-$color-primary-light4: #a366e0;
-$color-primary-light5: #b380e6;
-$color-primary-light6: #c299eb;
-$color-primary-light7: #d1b3f0;
-$color-primary-light8: #e0ccf5;
-$color-primary-light9: #f0e6fa;
-
-// フューチャーブルーバリエーション
+// フューチャーブルー
 $color-secondary: #00c1d5;
-
-$color-secondary-dark1: #00aec0;
-$color-secondary-dark2: #009aaa;
-$color-secondary-dark3: #008795;
-$color-secondary-dark4: #007480;
-$color-secondary-dark5: #00616b;
-$color-secondary-dark6: #004d55;
-$color-secondary-dark7: #003a40;
-$color-secondary-dark8: #00272b;
-$color-secondary-dark9: #001315;
-
-$color-secondary-light1: #1ac7d9;
-$color-secondary-light2: #33cddd;
-$color-secondary-light3: #4dd4e2;
-$color-secondary-light4: #66dae6;
-$color-secondary-light5: #80e0ea;
-$color-secondary-light6: #99e6ee;
-$color-secondary-light7: #b3ecf2;
-$color-secondary-light8: #ccf3f7;
-$color-secondary-light9: #e6f9fb;


### PR DESCRIPTION
## 修正するIssue

#70 

## 変更点

- `vars.scss` につくば紫(`#6600cc`)とフューチャーブルー(`#00c1d5`)とそのバリエーションを追加しました
- `#ffffff`との色コントラストが確保できるよう、リンクテキスト色をつくば紫に変更しました
- #73 マージに伴いフッターの背景色を `#ffffff` に変更しました

変更点が複数のPRになってしまいすいません…いずれも #70 で出た話で…