### PR TITLE
[Fix] Instagramのリンク設定ミスを修正 fix #114

### DIFF
--- a/src/templates/PostTemplate.js
+++ b/src/templates/PostTemplate.js
@@ -194,7 +194,7 @@ const InfoNav = ({
               )}
               {isInstagramAvailable ? (
                 <a // Instagram
-                  href={`https://twitter.com/${instagram}`}
+                  href={`https://www.instagram.com/${instagram}`}
                   rel="noopener noreferrer"
                   target="_blank"
                   className="icon icon--instagram"


### PR DESCRIPTION
## 修正するIssue

#114

## 変更点

InstagramリンクがTwitterドメインに張られていたのを修正
