### PR TITLE
[Fix] og:site_nameとtwitter:titleを設定 fix 117

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -45,7 +45,7 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           property: `og:site_name`,
-          content: "筑波大学新歓Web",
+          content: site.siteMetadata.title,
         },
         {
           property: `og:description`,
@@ -65,7 +65,7 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           name: `twitter:title`,
-          content: `${title} | 筑波大学新歓Web`,
+          content: `${title} | ${site.siteMetadata.title}`,
         },
         {
           name: `twitter:description`,

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -44,6 +44,10 @@ function SEO({ description, lang, meta, title }) {
           content: title,
         },
         {
+          property: `og:site_name`,
+          content: "筑波大学新歓Web",
+        },
+        {
           property: `og:description`,
           content: metaDescription,
         },
@@ -61,7 +65,7 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           name: `twitter:title`,
-          content: title,
+          content: `${title} | 筑波大学新歓Web`,
         },
         {
           name: `twitter:description`,


### PR DESCRIPTION
## 修正するIssue

#117 

## 変更点

- `og:site_name` に `筑波大学新歓Web` を設定しました
- `twitter:title` に `ページタイトル | 筑波大学新歓Web` を設定しました