### PR TITLE
[Fix] og:descriptionを設定

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -6,7 +6,10 @@ import SEO from "../components/seo"
 
 const aboutPage = () => (
   <Layout>
-    <SEO title="このサイトについて" />
+    <SEO
+      title="このサイトについて"
+      description="このサイトは2020年度の新歓活動が新型コロナウイルスの影響により大幅に制限されることを受け、筑波大学Webページ学生委員会が中心となって製作しました。 筑波大学内のサークル等の団体のポータルサイトとしてご活用いただければ幸いです。"
+    />
     <div className="page--about">
       <div className="about--paragraph">
         <h1>このサイトについて</h1>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -37,7 +37,7 @@ const IndexPage = () => {
                   <figcaption>
                     <h2 className="org-list__item__name">{org.name}</h2>
                     <p className="org-list__item__activity-introduce">
-                      {org.activityIntroduce.substr(0, 100) + "..."}
+                      {org.activityIntroduce.slice(0, 100) + "..."}
                     </p>
                   </figcaption>
                 </figure>
@@ -55,7 +55,7 @@ const IndexPage = () => {
                   {org.name}
                 </div>
                 <div className="org-list__item__sp-caption__activity-introduce">
-                  {org.activityIntroduce.substr(0, 100) + "..."}
+                  {org.activityIntroduce.slice(0, 100) + "..."}
                 </div>
               </div>
             </li>

--- a/src/templates/PostTemplate.js
+++ b/src/templates/PostTemplate.js
@@ -26,7 +26,10 @@ const Post = ({ data }) => {
 
   return (
     <Layout>
-      <SEO title={org.name} />
+      <SEO
+        title={org.name}
+        description={org.activityIntroduce.substr(0, 200)}
+      />
       <div className="post-template">
         <div className="post-template__container">
           <section // ページ左側: ビジュアルカラム

--- a/src/templates/PostTemplate.js
+++ b/src/templates/PostTemplate.js
@@ -26,10 +26,7 @@ const Post = ({ data }) => {
 
   return (
     <Layout>
-      <SEO
-        title={org.name}
-        description={org.activityIntroduce.substr(0, 200)}
-      />
+      <SEO title={org.name} description={org.activityIntroduce.slice(0, 200)} />
       <div className="post-template">
         <div className="post-template__container">
           <section // ページ左側: ビジュアルカラム


### PR DESCRIPTION
## 修正するIssue

#116 

## 変更点

- 個別ページの`description`を`activityIntroduce`の先頭200字に設定
- これまでトップページと同じだったaboutページの`description`を当該ページの一段落目に設定(ハードコーディング)

- (追加) 文字列抽出を`substr`で実装していたが、`index.js`の同様の記述と共に`slice`に置き換え

なお、これにより`description`/`og:description`/`twitter:description`の3つが全て変更されます。