### PR TITLE
スマホでのトップページ横方向のあふれを修正

### DIFF
--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -12,6 +12,7 @@
   grid-gap: 20px;
   padding: 0;
   margin: 20px 40px;
+  overflow-x: hidden;
   list-style-type: none;
 
   @include mq-down() {


### PR DESCRIPTION
## 修正するIssue

Fix #120 

## 変更点

* ポスターのリスト全体に`overflow-x: hidden`の追記
  * これ、あふれているのはホバー時に出てくる要素のどれか（不可視）ですね多分……
