### PR TITLE
[Chore] ビルド時にGatsbyのキャッシュを利用するように変更（修正版）

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,11 +40,11 @@ jobs:
       with:
         path: ./.cache
         key: ${{ runner.os }}-gatsby-dev-dot-cache-${{ hashFiles('**/package.json') }}
-      - name: "Use cache for Gatsby /public"
-        uses: actions/cache@v1
-        with:
-          path: ./public
-          key: ${{ runner.os }}-gatsby-dev-public-${{ hashFiles('**/package.json') }}
+    - name: "Use cache for Gatsby /public"
+      uses: actions/cache@v1
+      with:
+        path: ./public
+        key: ${{ runner.os }}-gatsby-dev-public-${{ hashFiles('**/package.json') }}
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,11 +35,16 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - name: "Use cache for Gatsby"
+    - name: "Use cache for Gatsby /.cache"
       uses: actions/cache@v1
       with:
         path: ./.cache
-        key: ${{ runner.os }}-gatsby-dev-${{ hashFiles('**/package.json') }}
+        key: ${{ runner.os }}-gatsby-dev-dot-cache-${{ hashFiles('**/package.json') }}
+      - name: "Use cache for Gatsby /public"
+        uses: actions/cache@v1
+        with:
+          path: ./public
+          key: ${{ runner.os }}-gatsby-dev-public-${{ hashFiles('**/package.json') }}
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
@@ -64,12 +69,17 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - name: "Use cache for Gatsby"
+    - name: "Use cache for Gatsby .cache"
       uses: actions/cache@v1
       if: github.ref == 'refs/heads/master'
       with:
         path: ./.cache
-        key: ${{ runner.os }}-gatsby-prod-${{ hashFiles('**/package.json') }}
+        key: ${{ runner.os }}-gatsby-prod-dot-cache-${{ hashFiles('**/package.json') }}
+    - name: "Use cache for Gatsby /public"
+      uses: actions/cache@v1
+      with:
+        path: ./public
+        key: ${{ runner.os }}-gatsby-prod-public-${{ hashFiles('**/package.json') }}
     - name: "Clear source data"
       shell: bash
       run: rm -rf ./.cache/caches/@tsukuba-shinkan


### PR DESCRIPTION
## 修正するIssue

メンテナンスのためIssueなし

## 変更点

* ビルド時に`/.cache`および`/public`をキャッシュして利用する
  * #130 で`/public`が対象から抜けていたので修正したバージョン
