### PR TITLE
[Fix] 個別ページotherImagesの幅溢れを解消

### DIFF
--- a/src/templates/PostTemplate.scss
+++ b/src/templates/PostTemplate.scss
@@ -138,12 +138,27 @@
         border: 1px solid #bbb;
 
         @include mq-down() {
+          position: relative;
+          width: auto;
+          height: auto;
           margin-bottom: 0;
+
+          &::before {
+            display: block;
+            margin-bottom: 100%;
+            content: '';
+          }
         }
 
         .gatsby-image-wrapper {
           width: 100%;
           height: 100%;
+
+          @include mq-down() {
+            position: absolute !important;
+            top: 0;
+            left: 0;
+          }
         }
       }
     }


### PR DESCRIPTION
## 修正するIssue

Fix #136 

## 変更点

* 固定ページ`otherImages`の幅が絶対値で指定されていたのを解除
* アスペクト比維持のためのスタイルを追加

![image](https://user-images.githubusercontent.com/7803255/79176806-31640f00-7e3c-11ea-95ca-7932f794388c.png)
