### PR TITLE
[FIx] base64プレースホルダ画像の生成を廃止

### DIFF
--- a/src/components/Fluid200.js
+++ b/src/components/Fluid200.js
@@ -9,7 +9,7 @@ export default function Fluid200({ url, alt }) {
         nodes {
           id
           fluid(maxWidth: 200) {
-            ...GatsbyImageSharpFluid
+            ...GatsbyImageSharpFluid_noBase64
           }
           parent {
             ... on File {

--- a/src/components/Fluid700.js
+++ b/src/components/Fluid700.js
@@ -9,7 +9,7 @@ export default function Fluid700({ url, alt }) {
         nodes {
           id
           fluid(maxWidth: 700) {
-            ...GatsbyImageSharpFluid
+            ...GatsbyImageSharpFluid_noBase64
           }
           parent {
             ... on File {


### PR DESCRIPTION
## 修正するIssue

Fix #144

## 変更点

Fluid200.js, Fluid700.js でbase64プレースホルダ画像の生成を廃止しました
